### PR TITLE
Catch all exception when consume kafka record

### DIFF
--- a/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/KafkaFetcherHandlerRegister.java
+++ b/oap-server/server-fetcher-plugin/kafka-fetcher-plugin/src/main/java/org/apache/skywalking/oap/server/analyzer/agent/kafka/KafkaFetcherHandlerRegister.java
@@ -137,7 +137,11 @@ public class KafkaFetcherHandlerRegister implements Runnable {
                 Iterator<ConsumerRecord<String, Bytes>> iterator = consumerRecords.iterator();
                 while (iterator.hasNext()) {
                     ConsumerRecord<String, Bytes> record = iterator.next();
-                    handlerMap.get(record.topic()).handle(record);
+                    try {
+                        handlerMap.get(record.topic()).handle(record);
+                    } catch(Throwable t) {
+                        log.error("consume record error", t);
+                    }
                 }
                 consumer.commitAsync();
             }


### PR DESCRIPTION
KafkaFetcher Consume Record from kafka, but when One Record IS BAD, data has some error, or even just occur some error when process the data, it will terminate the  "ConsumerThread", NO data can processed anymore.

There is a Dirty & Quick fix, try catch all exception.